### PR TITLE
Add stack realign flag to accommodate Mac x86 calling convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -m32 -std=gnu99 -O2
+CFLAGS = -Wall -m32 -mstackrealign -std=gnu99 -O2
 C = $(CC) $(CFLAGS)
 
 rubi: engine.o expr.o parser.o stdlib.o


### PR DESCRIPTION
- Mac demands esp be 16-byte aligned upon function call
- `-mstackrealign` flags realigns esp in the prologue of all functions

However, this flag is only needed on Mac platforms.
