### PR TITLE
replaceEscape memory access out-of-bound

### DIFF
--- a/asm.h
+++ b/asm.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-unsigned char *ntvCode;
+unsigned char ntvCode[0x10000] __attribute__((aligned(4)));
 int ntvCount;
 
 enum { EAX = 0, ECX, EDX, EBX, ESP, EBP, ESI, EDI };

--- a/engine.c
+++ b/engine.c
@@ -8,8 +8,6 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
-#include <sys/mman.h>
-#include <sys/wait.h>
 
 struct {
     uint32_t addr[0xff];
@@ -21,11 +19,6 @@ static void set_xor128() { w = 1234 + (getpid() ^ 0xFFBA9285); }
 
 void init()
 {
-    long memsz = 0xFFFF + 1;
-    if (posix_memalign((void **) &ntvCode, memsz, memsz))
-        perror("posix_memalign");
-    if (mprotect(ntvCode, memsz, PROT_READ | PROT_WRITE | PROT_EXEC))
-        perror("mprotect");
     tok.pos = ntvCount = 0;
     tok.size = 0xfff;
     set_xor128();

--- a/engine.c
+++ b/engine.c
@@ -38,7 +38,6 @@ static void freeAddr()
 
 void dispose()
 {
-    free(ntvCode);
     free(brks.addr);
     free(rets.addr);
     free(tok.tok);


### PR DESCRIPTION
Fix memory access out-of-bound access bug in `replaceEscape`
