### PR TITLE
To correct fibonacci

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ end
 ```ruby
 def fib(n)
     if n < 2
-        1
+        n
     else
         fib(n - 1) + fib(n - 2)
     end

--- a/progs/fib.rb
+++ b/progs/fib.rb
@@ -1,6 +1,6 @@
 def fib(n)
 	if n < 2
-		1
+		n
 	else
 		fib(n - 1) + fib(n - 2)
 	end


### PR DESCRIPTION
Hi guys,
There is a small issue in ruby code of fibonacci method which returned the wrong answer.
`fib(2)` should be 1, not 2. 
It would lead all answers shifted. i.e. `fib(n)` equals to corrected fibonacci(n+1)

I tried to fix it, so just check it if its helpful :)
